### PR TITLE
chore: update notification logic

### DIFF
--- a/apps/worker/src/http/routes/documents.routes.ts
+++ b/apps/worker/src/http/routes/documents.routes.ts
@@ -35,7 +35,7 @@ documentsRoutes.get('/document-files/:documentId', async (c) => {
   return new Response(object.body, {
     headers: {
       'Content-Type':
-        object.httpMetadata?.contentType ?? 'text/html; charset=utf-8',
+        object.httpMetadata?.contentType ?? 'application/pdf',
       'Content-Disposition': `inline; filename="${document.fileName}"`,
     },
   });

--- a/apps/worker/src/http/routes/trigger.routes.ts
+++ b/apps/worker/src/http/routes/trigger.routes.ts
@@ -21,6 +21,26 @@ type TriggerRequestBody = {
 
 const triggerRoutes = new Hono<AppEnv>();
 
+const getInitialReviewRequests = <
+  T extends { documentId: string; signOrder: number },
+>(
+  reviewRequests: T[],
+) => {
+  const minOrderByDocument = new Map<string, number>();
+
+  for (const reviewRequest of reviewRequests) {
+    const current = minOrderByDocument.get(reviewRequest.documentId);
+    if (current == null || reviewRequest.signOrder < current) {
+      minOrderByDocument.set(reviewRequest.documentId, reviewRequest.signOrder);
+    }
+  }
+
+  return reviewRequests.filter(
+    (reviewRequest) =>
+      minOrderByDocument.get(reviewRequest.documentId) === reviewRequest.signOrder,
+  );
+};
+
 triggerRoutes.post('/trigger', async (c) => {
   const body = await c.req.json<TriggerRequestBody>();
   const employeeId = body.employeeId?.trim();
@@ -70,7 +90,7 @@ triggerRoutes.post('/trigger', async (c) => {
       estimatedCompletionMs: 8000,
       documents: snapshot?.documents ?? [],
       reviewRequests:
-        snapshot?.reviewRequests.map((reviewRequest) => ({
+        getInitialReviewRequests(snapshot?.reviewRequests ?? []).map((reviewRequest) => ({
           ...reviewRequest,
           reviewUrl: `/api/v1/reviews/${reviewRequest.reviewToken}`,
         })) ?? [],

--- a/apps/worker/src/modules/action/action.service.ts
+++ b/apps/worker/src/modules/action/action.service.ts
@@ -108,7 +108,7 @@ export const parseDocuments = (action: Pick<ActionRecord, 'documentsJson'>) => {
       document.templateName ?? document.template ?? `${documentType}.html`;
     const fileName =
       document.fileName ??
-      templateName.replace(/\.(docx|pdf)$/i, '.html');
+      templateName.replace(/\.(docx|html)$/i, '.pdf');
 
     return {
       documentType,

--- a/apps/worker/src/modules/document/document.service.ts
+++ b/apps/worker/src/modules/document/document.service.ts
@@ -66,18 +66,18 @@ export const updateGeneratedDocument = async (
   return repoUpdateGeneratedDocument(env, id, input);
 };
 
-export const storeGeneratedDocumentHtml = async (
+export const storeGeneratedDocumentPdf = async (
   env: EnvWithBindings,
   storagePath: string,
-  htmlContent: string,
+  pdfBytes: Uint8Array,
 ) => {
   if (!env.DOCS_BUCKET) {
     return;
   }
 
-  await env.DOCS_BUCKET.put(storagePath, htmlContent, {
+  await env.DOCS_BUCKET.put(storagePath, pdfBytes, {
     httpMetadata: {
-      contentType: 'text/html; charset=utf-8',
+      contentType: 'application/pdf',
     },
   });
 };

--- a/apps/worker/src/modules/job/job.notifications.ts
+++ b/apps/worker/src/modules/job/job.notifications.ts
@@ -1,9 +1,7 @@
 import { logEvent } from '../audit/audit.service';
 import {
-  buildDocumentsGeneratedNotifications,
   buildReviewNotifications,
   emitWorkflowNotifications,
-  resolveGeneratedDocumentRecipients,
 } from '../workflow/workflow.service';
 import type { EnvWithBindings } from './job.types';
 import type {
@@ -13,6 +11,22 @@ import type {
   TriggerContext,
 } from './job.workflow';
 
+function getInitialReviewRequests(reviewRequests: ReviewRequestRecord[]) {
+  const minOrderByDocument = new Map<string, number>();
+
+  for (const reviewRequest of reviewRequests) {
+    const current = minOrderByDocument.get(reviewRequest.documentId);
+    if (current == null || reviewRequest.signOrder < current) {
+      minOrderByDocument.set(reviewRequest.documentId, reviewRequest.signOrder);
+    }
+  }
+
+  return reviewRequests.filter(
+    (reviewRequest) =>
+      minOrderByDocument.get(reviewRequest.documentId) === reviewRequest.signOrder,
+  );
+}
+
 export async function emitWorkflowGenerationNotifications(
   env: EnvWithBindings,
   context: TriggerContext,
@@ -21,20 +35,13 @@ export async function emitWorkflowGenerationNotifications(
   createdDocuments: GeneratedDocumentRecord[],
   createdReviewRequests: ReviewRequestRecord[],
 ) {
-  const generatedDocumentRecipients = await resolveGeneratedDocumentRecipients(
-    env,
-    context.employee,
-    context.actionPayload,
-    context.input.requestedByEmail,
-  );
-
   await logEvent(env, {
     jobId: job.id,
     employeeId: context.employee.id,
     actionName: context.action.actionName,
     eventType: 'documents_generated',
     documents: createdDocuments,
-    recipients: generatedDocumentRecipients,
+    recipients: context.workflowRecipients,
     status: 'success',
     message: `${createdDocuments.length} documents generated`,
   });
@@ -49,24 +56,17 @@ export async function emitWorkflowGenerationNotifications(
       documentId: reviewRequest.documentId,
       reviewerEmail: reviewRequest.reviewerEmail,
       signerRole: reviewRequest.signerRole,
+      signOrder: reviewRequest.signOrder,
     })),
     status: 'success',
     message: `${createdReviewRequests.length} review requests created`,
   });
 
-  const documentNotifications = buildDocumentsGeneratedNotifications({
-    job: activeJob ?? job,
-    employee: context.employee,
-    documents: createdDocuments,
-    recipients: generatedDocumentRecipients,
-    baseUrl: env.APP_BASE_URL,
-  });
-  await emitWorkflowNotifications(env, documentNotifications);
-
+  const initialReviewRequests = getInitialReviewRequests(createdReviewRequests);
   const notifications = buildReviewNotifications({
     job: activeJob ?? job,
     documents: createdDocuments,
-    reviewRequests: createdReviewRequests,
+    reviewRequests: initialReviewRequests,
     baseUrl: env.APP_BASE_URL,
   });
   await emitWorkflowNotifications(env, notifications);

--- a/apps/worker/src/modules/job/job.workflow.ts
+++ b/apps/worker/src/modules/job/job.workflow.ts
@@ -1,14 +1,14 @@
 import { logEvent } from '../audit/audit.service';
 import {
   addGeneratedDocument,
-  storeGeneratedDocumentHtml,
+  storeGeneratedDocumentPdf,
   updateGeneratedDocument,
 } from '../document/document.service';
 import { createReviewRequest } from '../review/review.service';
 import { getTemplateByName } from '../templates/templates.service';
 import {
   buildDocumentFileUrl,
-  buildWorkflowDocumentHtml,
+  buildWorkflowDocumentPdf,
   parseWorkflowPayload,
   resolveWorkflowRecipients,
 } from '../workflow/workflow.service';
@@ -114,7 +114,7 @@ export async function generateWorkflowArtifacts(
         documentConfig.generationOrder,
         documentConfig.fileName,
       );
-    const htmlContent = buildWorkflowDocumentHtml({
+    const pdfBytes = buildWorkflowDocumentPdf({
       documentType: documentConfig.documentType,
       actionName: context.action.actionName,
       employee: context.employee,
@@ -143,7 +143,7 @@ export async function generateWorkflowArtifacts(
       );
     }
 
-    await storeGeneratedDocumentHtml(env, storagePath, htmlContent);
+    await storeGeneratedDocumentPdf(env, storagePath, pdfBytes);
 
     const updatedDocument = await updateGeneratedDocument(env, document.id, {
       fileUrl: buildDocumentFileUrl(document.id),

--- a/apps/worker/src/modules/review/review.service.ts
+++ b/apps/worker/src/modules/review/review.service.ts
@@ -1,5 +1,10 @@
 import { logEvent } from '../audit/audit.service';
+import { getGeneratedDocumentById } from '../document/document.service';
 import { getJobById as repoGetJobById } from '../job/job.repository';
+import {
+  buildReviewNotifications,
+  emitWorkflowNotifications,
+} from '../workflow/workflow.service';
 import {
   createReviewRequest as repoCreateReviewRequest,
   getReviewRequestByToken as repoGetReviewRequestByToken,
@@ -9,6 +14,104 @@ import {
 import { syncDocumentAndJobStatus } from './review.status';
 import type { EnvWithBindings } from './review.types';
 import { nowIso } from './review.utils';
+
+const isPendingReviewStatus = (status: string) =>
+  status === 'awaiting_review' || status === 'opened';
+
+async function assertReviewOrderReady(
+  env: EnvWithBindings,
+  review: { documentId: string; signOrder: number },
+) {
+  const documentReviews = await repoListReviewRequests(env, {
+    documentId: review.documentId,
+  });
+  const blockedByPriorSigner = documentReviews.some(
+    (candidate) =>
+      candidate.signOrder < review.signOrder && candidate.status !== 'approved',
+  );
+
+  if (blockedByPriorSigner) {
+    throw new Error('This review is waiting for an earlier signer');
+  }
+}
+
+async function notifyNextReviewers(
+  env: EnvWithBindings,
+  input: {
+    jobId: string;
+    documentId: string;
+    releasedBySignOrder: number;
+  },
+) {
+  const [job, document, documentReviews] = await Promise.all([
+    repoGetJobById(env, input.jobId),
+    getGeneratedDocumentById(env, input.documentId),
+    repoListReviewRequests(env, { documentId: input.documentId }),
+  ]);
+
+  if (!job || !document) {
+    return;
+  }
+
+  const waitingOnCurrentOrder = documentReviews.some(
+    (review) =>
+      review.signOrder === input.releasedBySignOrder &&
+      isPendingReviewStatus(review.status),
+  );
+
+  if (waitingOnCurrentOrder) {
+    return;
+  }
+
+  const nextSignOrder = documentReviews
+    .filter(
+      (review) =>
+        review.signOrder > input.releasedBySignOrder &&
+        isPendingReviewStatus(review.status),
+    )
+    .reduce<number | null>(
+      (current, review) =>
+        current == null || review.signOrder < current ? review.signOrder : current,
+      null,
+    );
+
+  if (nextSignOrder == null) {
+    return;
+  }
+
+  const nextReviewRequests = documentReviews.filter(
+    (review) =>
+      review.signOrder === nextSignOrder && isPendingReviewStatus(review.status),
+  );
+
+  if (nextReviewRequests.length === 0) {
+    return;
+  }
+
+  const notifications = buildReviewNotifications({
+    job,
+    documents: [document],
+    reviewRequests: nextReviewRequests,
+    baseUrl: env.APP_BASE_URL,
+  });
+
+  await emitWorkflowNotifications(env, notifications);
+
+  await logEvent(env, {
+    jobId: job.id,
+    employeeId: job.employeeId,
+    actionName: job.actionName,
+    eventType: 'review_requests_released',
+    eventPayload: nextReviewRequests.map((review) => ({
+      id: review.id,
+      reviewerEmail: review.reviewerEmail,
+      signOrder: review.signOrder,
+      documentId: review.documentId,
+    })),
+    status: 'success',
+    message: `Released sign order ${nextSignOrder} for ${document.documentType}`,
+  });
+}
 
 export const getReviewRequests = async (
   env: EnvWithBindings,
@@ -120,6 +223,8 @@ export const approveReviewRequest = async (
     throw new Error('Rejected review request cannot be approved');
   }
 
+  await assertReviewOrderReady(env, review);
+
   const approvedReview = await repoUpdateReviewRequest(env, review.id, {
     status: 'approved',
     reviewerName: input?.reviewerName ?? review.reviewerName,
@@ -147,6 +252,11 @@ export const approveReviewRequest = async (
   }
 
   await syncDocumentAndJobStatus(env, review.jobId, review.documentId);
+  await notifyNextReviewers(env, {
+    jobId: review.jobId,
+    documentId: review.documentId,
+    releasedBySignOrder: review.signOrder,
+  });
 
   return approvedReview;
 };
@@ -171,6 +281,8 @@ export const rejectReviewRequest = async (
   if (review.status === 'rejected') {
     return review;
   }
+
+  await assertReviewOrderReady(env, review);
 
   const rejectedReview = await repoUpdateReviewRequest(env, review.id, {
     status: 'rejected',

--- a/apps/worker/src/modules/review/review.status.ts
+++ b/apps/worker/src/modules/review/review.status.ts
@@ -2,7 +2,7 @@ import { logEvent } from '../audit/audit.service';
 import {
   getGeneratedDocumentById,
   getGeneratedDocuments,
-  storeGeneratedDocumentHtml,
+  storeGeneratedDocumentPdf,
   updateGeneratedDocument,
 } from '../document/document.service';
 import { getEmployeeById } from '../employee/employee.service';
@@ -11,13 +11,24 @@ import { getTemplateByName } from '../templates/templates.service';
 import {
   buildCompletionNotifications,
   buildDocumentFileUrl,
-  buildWorkflowDocumentHtml,
+  buildWorkflowDocumentPdf,
   emitWorkflowNotifications,
   parseWorkflowPayload,
+  resolveGeneratedDocumentRecipients,
 } from '../workflow/workflow.service';
 import { listReviewRequests as repoListReviewRequests } from './review.repository';
 import type { EnvWithBindings } from './review.types';
 import { nowIso, reviewsToWorkflowRecipients } from './review.utils';
+
+function dedupeRecipients<T extends { email: string; role: string }>(recipients: T[]) {
+  return recipients.filter(
+    (recipient, index, current) =>
+      current.findIndex(
+        (candidate) =>
+          candidate.email === recipient.email && candidate.role === recipient.role,
+      ) === index,
+  );
+}
 
 export async function syncDocumentAndJobStatus(
   env: EnvWithBindings,
@@ -31,6 +42,15 @@ export async function syncDocumentAndJobStatus(
     return;
   }
 
+  const employee = await getEmployeeById(env, job.employeeId);
+
+  if (!employee) {
+    throw new Error(`Employee not found: ${job.employeeId}`);
+  }
+
+  const payload = parseWorkflowPayload(
+    job.inputPayloadJson ? JSON.parse(job.inputPayloadJson) : {},
+  );
   const documentReviews = await repoListReviewRequests(env, { documentId });
   const allDocumentApproved =
     documentReviews.length > 0 &&
@@ -38,60 +58,52 @@ export async function syncDocumentAndJobStatus(
   const anyDocumentRejected = documentReviews.some(
     (review) => review.status === 'rejected',
   );
+  const documentStatus = anyDocumentRejected
+    ? 'rejected'
+    : allDocumentApproved
+      ? 'completed'
+      : documentReviews.some((review) => review.status === 'approved')
+        ? 'partially_signed'
+        : 'awaiting_signatures';
+  const workflowRecipients = reviewsToWorkflowRecipients(documentReviews);
+  const template = await getTemplateByName(env, document.templateName);
+  const approvalSummary = documentReviews.map((review) => ({
+    reviewerEmail: review.reviewerEmail,
+    reviewerName: review.reviewerName,
+    approvedAt: review.approvedAt,
+    signMethod: review.signMethod,
+  }));
+  const pdfBytes = buildWorkflowDocumentPdf({
+    documentType: document.documentType,
+    actionName: job.actionName,
+    employee,
+    payload,
+    recipients: workflowRecipients,
+    status: documentStatus,
+    templateHtml: template?.htmlContent ?? null,
+    approvalSummary,
+  });
+  const approvedReviews = documentReviews.filter(
+    (review) => review.status === 'approved',
+  );
+  const lastSignedReview = [...approvedReviews]
+    .reverse()
+    .find((review) => Boolean(review.signatureImageUrl));
 
-  if (anyDocumentRejected && document.status !== 'rejected') {
-    await updateGeneratedDocument(env, document.id, {
-      status: 'rejected',
-    });
-  }
+  await storeGeneratedDocumentPdf(env, document.storagePath, pdfBytes);
+  await updateGeneratedDocument(env, document.id, {
+    status: documentStatus,
+    fileUrl: buildDocumentFileUrl(document.id),
+    signedBy: approvedReviews.map((review) => review.reviewerEmail).join(', ') || null,
+    signedAt: allDocumentApproved ? nowIso() : null,
+    signMethod:
+      approvedReviews.map((review) => review.signMethod).filter(Boolean).join(', ') ||
+      null,
+    signatureImageUrl: lastSignedReview?.signatureImageUrl ?? null,
+    finalizedAt: allDocumentApproved ? nowIso() : null,
+  });
 
   if (allDocumentApproved && document.status !== 'completed') {
-    const employee = await getEmployeeById(env, job.employeeId);
-
-    if (!employee) {
-      throw new Error(`Employee not found: ${job.employeeId}`);
-    }
-
-    const template = await getTemplateByName(env, document.templateName);
-    const workflowRecipients = reviewsToWorkflowRecipients(documentReviews);
-    const payload = parseWorkflowPayload(
-      job.inputPayloadJson ? JSON.parse(job.inputPayloadJson) : {},
-    );
-    const finalizedAt = nowIso();
-    const htmlContent = buildWorkflowDocumentHtml({
-      documentType: document.documentType,
-      actionName: job.actionName,
-      employee,
-      payload,
-      recipients: workflowRecipients,
-      status: 'completed',
-      templateHtml: template?.htmlContent ?? null,
-      approvalSummary: documentReviews.map((review) => ({
-        reviewerEmail: review.reviewerEmail,
-        reviewerName: review.reviewerName,
-        approvedAt: review.approvedAt,
-        signMethod: review.signMethod,
-      })),
-    });
-
-    await storeGeneratedDocumentHtml(env, document.storagePath, htmlContent);
-    const lastSignedReview = [...documentReviews]
-      .reverse()
-      .find((review) => Boolean(review.signatureImageUrl));
-
-    await updateGeneratedDocument(env, document.id, {
-      status: 'completed',
-      fileUrl: buildDocumentFileUrl(document.id),
-      signedBy: documentReviews.map((review) => review.reviewerEmail).join(', '),
-      signedAt: finalizedAt,
-      signMethod: documentReviews
-        .map((review) => review.signMethod)
-        .filter(Boolean)
-        .join(', '),
-      signatureImageUrl: lastSignedReview?.signatureImageUrl ?? null,
-      finalizedAt,
-    });
-
     await logEvent(env, {
       jobId: job.id,
       employeeId: job.employeeId,
@@ -104,16 +116,6 @@ export async function syncDocumentAndJobStatus(
       status: 'success',
       message: `${document.documentType} completed`,
     });
-  } else if (!allDocumentApproved && !anyDocumentRejected) {
-    const nextStatus = documentReviews.some((review) => review.status === 'approved')
-      ? 'partially_signed'
-      : 'awaiting_signatures';
-
-    if (document.status !== nextStatus) {
-      await updateGeneratedDocument(env, document.id, {
-        status: nextStatus,
-      });
-    }
   }
 
   const jobReviews = await repoListReviewRequests(env, { jobId });
@@ -143,16 +145,26 @@ export async function syncDocumentAndJobStatus(
   if (allJobApproved && job.status !== 'completed') {
     const finalizedAt = nowIso();
     const documents = await getGeneratedDocuments(env, { jobId });
-    const recipients = reviewsToWorkflowRecipients(
-      jobReviews.filter(
-        (review, index, current) =>
-          current.findIndex(
-            (candidate) =>
-              candidate.reviewerEmail === review.reviewerEmail &&
-              candidate.signerRole === review.signerRole,
-          ) === index,
+    const signerRecipients = dedupeRecipients(
+      reviewsToWorkflowRecipients(
+        jobReviews.map((review) => ({
+          reviewerEmail: review.reviewerEmail,
+          reviewerName: review.reviewerName,
+          signerRole: review.signerRole,
+          signOrder: review.signOrder,
+        })),
       ),
     );
+    const generatedRecipients = await resolveGeneratedDocumentRecipients(
+      env,
+      employee,
+      payload,
+      job.requestedByEmail ?? undefined,
+    );
+    const completionRecipients = dedupeRecipients([
+      ...signerRecipients,
+      ...generatedRecipients,
+    ]);
 
     await updateJob(env, job.id, {
       status: 'completed',
@@ -167,7 +179,7 @@ export async function syncDocumentAndJobStatus(
       actionName: job.actionName,
       eventType: 'job_completed',
       documents,
-      recipients,
+      recipients: completionRecipients,
       status: 'success',
       message: 'All signatures completed',
     });
@@ -175,7 +187,7 @@ export async function syncDocumentAndJobStatus(
     const notifications = buildCompletionNotifications({
       job,
       documents,
-      recipients,
+      recipients: completionRecipients,
       baseUrl: env.APP_BASE_URL,
     });
     await emitWorkflowNotifications(env, notifications);

--- a/apps/worker/src/modules/workflow/workflow.documents.ts
+++ b/apps/worker/src/modules/workflow/workflow.documents.ts
@@ -1,10 +1,18 @@
+import { renderTemplateHtml } from '../templates/templates.service';
 import type {
   EmployeeLike,
   WorkflowPayload,
   WorkflowRecipient,
 } from './workflow.types';
 
-export const buildWorkflowDocumentHtml = (input: {
+type ApprovalSummary = {
+  reviewerEmail: string;
+  reviewerName: string | null;
+  approvedAt: string | null;
+  signMethod: string | null;
+};
+
+type WorkflowDocumentInput = {
   documentType: string;
   actionName: string;
   employee: EmployeeLike;
@@ -12,39 +20,151 @@ export const buildWorkflowDocumentHtml = (input: {
   recipients: WorkflowRecipient[];
   status: string;
   templateHtml?: string | null;
-  approvalSummary?: Array<{
-    reviewerEmail: string;
-    reviewerName: string | null;
-    approvedAt: string | null;
-    signMethod: string | null;
-  }>;
-}) => {
+  approvalSummary?: ApprovalSummary[];
+};
+
+type PdfLine = {
+  text: string;
+  fontSize: number;
+  lineHeight: number;
+};
+
+const PDF_PAGE_WIDTH = 612;
+const PDF_PAGE_HEIGHT = 792;
+const PDF_MARGIN = 48;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringifyTemplateValue(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stringifyTemplateValue(entry)).join(', ');
+  }
+
+  if (isPlainObject(value)) {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+function appendFlattenedValues(
+  target: Record<string, string>,
+  prefix: string,
+  value: unknown,
+) {
+  if (!prefix) {
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
+      appendFlattenedValues(target, `${prefix}.${childKey}`, childValue);
+    }
+    return;
+  }
+
+  target[prefix] = stringifyTemplateValue(value);
+}
+
+function buildTemplateData(input: WorkflowDocumentInput) {
   const employeeName =
     `${input.employee.firstName} ${input.employee.lastName}`.trim();
-  const payloadEntries = Object.entries(input.payload);
-  const reviewerList = input.recipients
+  const approvalSummaryText = (input.approvalSummary ?? [])
+    .map((approval) => {
+      const reviewer = approval.reviewerName ?? approval.reviewerEmail;
+      const timestamp = approval.approvedAt ?? 'pending';
+      const method = approval.signMethod ? ` via ${approval.signMethod}` : '';
+      return `${reviewer} signed ${timestamp}${method}`;
+    })
+    .join('\n');
+  const recipientSummary = input.recipients
+    .map(
+      (recipient) =>
+        `${recipient.signOrder}. ${recipient.role}: ${recipient.name ?? recipient.email}`,
+    )
+    .join('\n');
+
+  const data: Record<string, string> = {
+    employeeName,
+    employeeId: input.employee.id,
+    firstName: input.employee.firstName,
+    lastName: input.employee.lastName,
+    employeeFirstName: input.employee.firstName,
+    employeeLastName: input.employee.lastName,
+    employeeEmail: input.employee.email ?? '',
+    department: input.employee.department ?? '',
+    branch: input.employee.branch ?? '',
+    actionName: input.actionName,
+    documentType: input.documentType,
+    status: input.status,
+    requiredSigners: recipientSummary,
+    approvalSummary: approvalSummaryText,
+    currentDate: new Date().toISOString(),
+    signature: approvalSummaryText ? 'Signed electronically' : '',
+  };
+
+  appendFlattenedValues(data, 'employee', input.employee);
+  appendFlattenedValues(data, 'payload', input.payload);
+
+  for (const [key, value] of Object.entries(input.employee as Record<string, unknown>)) {
+    data[key] = stringifyTemplateValue(value);
+  }
+
+  for (const [key, value] of Object.entries(input.payload)) {
+    data[key] = stringifyTemplateValue(value);
+  }
+
+  return data;
+}
+
+function buildWorkflowMetadataHtml(input: WorkflowDocumentInput) {
+  const recipientItems = input.recipients
     .map(
       (recipient) =>
         `<li><strong>${recipient.role}</strong>: ${recipient.name ?? recipient.email}</li>`,
     )
     .join('');
-  const approvalList = (input.approvalSummary ?? [])
-    .map(
-      (approval) =>
-        `<li>${approval.reviewerName ?? approval.reviewerEmail} - ${
-          approval.approvedAt ?? 'pending'
-        }${approval.signMethod ? ` (${approval.signMethod})` : ''}</li>`,
-    )
+  const approvalItems = (input.approvalSummary ?? [])
+    .map((approval) => {
+      const reviewer = approval.reviewerName ?? approval.reviewerEmail;
+      const timestamp = approval.approvedAt ?? 'pending';
+      const method = approval.signMethod ? ` (${approval.signMethod})` : '';
+      return `<li>${reviewer} - ${timestamp}${method}</li>`;
+    })
     .join('');
 
-  if (input.templateHtml) {
-    return input.templateHtml
-      .replaceAll('{{employeeName}}', employeeName)
-      .replaceAll('{{employeeId}}', input.employee.id)
-      .replaceAll('{{actionName}}', input.actionName)
-      .replaceAll('{{documentType}}', input.documentType)
-      .replaceAll('{{status}}', input.status);
-  }
+  return `
+  <section class="epas-workflow-summary">
+    <hr />
+    <h2>Workflow Summary</h2>
+    <p><strong>Document:</strong> ${input.documentType}</p>
+    <p><strong>Workflow:</strong> ${input.actionName}</p>
+    <p><strong>Status:</strong> ${input.status}</p>
+    <h3>Required Signers</h3>
+    <ul>${recipientItems || '<li>No signers configured</li>'}</ul>
+    <h3>Approval Status</h3>
+    <ul>${approvalItems || '<li>Pending signatures</li>'}</ul>
+  </section>`;
+}
+
+const defaultDocumentHtml = (input: WorkflowDocumentInput) => {
+  const employeeName =
+    `${input.employee.firstName} ${input.employee.lastName}`.trim();
+  const payloadEntries = Object.entries(input.payload);
 
   return `<!doctype html>
 <html lang="en">
@@ -55,15 +175,14 @@ export const buildWorkflowDocumentHtml = (input: {
       body { font-family: Arial, sans-serif; padding: 32px; color: #17202a; }
       h1 { margin-bottom: 8px; }
       h2 { margin-top: 24px; }
-      .meta { color: #566573; margin-bottom: 16px; }
-      ul { padding-left: 20px; }
       table { border-collapse: collapse; width: 100%; margin-top: 12px; }
       td, th { border: 1px solid #d5d8dc; padding: 8px; text-align: left; }
     </style>
   </head>
   <body>
     <h1>${input.documentType}</h1>
-    <div class="meta">${input.actionName} • ${input.status}</div>
+    <p><strong>Workflow:</strong> ${input.actionName}</p>
+    <p><strong>Status:</strong> ${input.status}</p>
     <p><strong>Employee:</strong> ${employeeName}</p>
     <p><strong>Department:</strong> ${input.employee.department ?? '-'}</p>
     <p><strong>Branch:</strong> ${input.employee.branch ?? '-'}</p>
@@ -84,10 +203,223 @@ export const buildWorkflowDocumentHtml = (input: {
         }
       </tbody>
     </table>
-    <h2>Required Signers</h2>
-    <ul>${reviewerList}</ul>
-    <h2>Approval Status</h2>
-    <ul>${approvalList || '<li>Pending signatures</li>'}</ul>
   </body>
 </html>`;
+};
+
+export const buildWorkflowDocumentHtml = (input: WorkflowDocumentInput) => {
+  const templateHtml = input.templateHtml?.trim()
+    ? renderTemplateHtml(input.templateHtml, buildTemplateData(input))
+    : defaultDocumentHtml(input);
+
+  return `${templateHtml}${buildWorkflowMetadataHtml(input)}`;
+};
+
+function decodeHtmlEntities(text: string) {
+  return text
+    .replaceAll('&nbsp;', ' ')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'");
+}
+
+function htmlToPlainText(html: string) {
+  const withLineBreaks = html
+    .replace(/<style[\s\S]*?<\/style>/gi, '\n')
+    .replace(/<script[\s\S]*?<\/script>/gi, '\n')
+    .replace(/<\/(h1|h2|h3|h4|h5|h6|p|div|section|article|tr|ul|ol|li)>/gi, '\n')
+    .replace(/<(br|hr)\s*\/?>/gi, '\n')
+    .replace(/<\/(td|th)>/gi, '  ')
+    .replace(/<li>/gi, '- ')
+    .replace(/<[^>]+>/g, ' ');
+
+  return decodeHtmlEntities(withLineBreaks)
+    .replace(/\r/g, '')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function wrapLine(text: string, fontSize: number) {
+  const maxChars = Math.max(
+    20,
+    Math.floor((PDF_PAGE_WIDTH - PDF_MARGIN * 2) / (fontSize * 0.52)),
+  );
+  const normalized = text.trim();
+
+  if (!normalized) {
+    return [''];
+  }
+
+  const words = normalized.split(/\s+/);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+    }
+
+    if (word.length <= maxChars) {
+      current = word;
+      continue;
+    }
+
+    let remainder = word;
+    while (remainder.length > maxChars) {
+      lines.push(remainder.slice(0, maxChars - 1) + '-');
+      remainder = remainder.slice(maxChars - 1);
+    }
+    current = remainder;
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+function buildPdfLines(text: string): PdfLine[] {
+  const rawLines = text.split('\n');
+  const lines: PdfLine[] = [];
+  const firstNonEmptyIndex = rawLines.findIndex((line) => line.trim());
+
+  for (const [index, rawLine] of rawLines.entries()) {
+    const trimmed = rawLine.trim();
+
+    if (!trimmed) {
+      lines.push({ text: '', fontSize: 11, lineHeight: 14 });
+      continue;
+    }
+
+    const isTitle = index === firstNonEmptyIndex;
+    const fontSize = isTitle ? 18 : 11;
+    const lineHeight = isTitle ? 24 : 14;
+
+    for (const wrappedLine of wrapLine(trimmed, fontSize)) {
+      lines.push({ text: wrappedLine, fontSize, lineHeight });
+    }
+  }
+
+  return lines;
+}
+
+function escapePdfText(text: string) {
+  const asciiSafeText = text.replace(/[^\x20-\x7E]/g, '?');
+
+  return asciiSafeText
+    .replaceAll('\\', '\\\\')
+    .replaceAll('(', '\\(')
+    .replaceAll(')', '\\)');
+}
+
+function buildPdfContent(pages: PdfLine[][]) {
+  return pages.map((pageLines) => {
+    let y = PDF_PAGE_HEIGHT - PDF_MARGIN;
+    const commands = ['BT'];
+
+    for (const line of pageLines) {
+      commands.push(`/F1 ${line.fontSize} Tf`);
+      commands.push(
+        `1 0 0 1 ${PDF_MARGIN} ${Number(y.toFixed(2))} Tm (${escapePdfText(
+          line.text,
+        )}) Tj`,
+      );
+      y -= line.lineHeight;
+    }
+
+    commands.push('ET');
+    return commands.join('\n');
+  });
+}
+
+function paginatePdfLines(lines: PdfLine[]) {
+  const pages: PdfLine[][] = [];
+  let currentPage: PdfLine[] = [];
+  let remainingHeight = PDF_PAGE_HEIGHT - PDF_MARGIN * 2;
+
+  for (const line of lines) {
+    if (currentPage.length > 0 && remainingHeight < line.lineHeight) {
+      pages.push(currentPage);
+      currentPage = [];
+      remainingHeight = PDF_PAGE_HEIGHT - PDF_MARGIN * 2;
+    }
+
+    currentPage.push(line);
+    remainingHeight -= line.lineHeight;
+  }
+
+  if (currentPage.length === 0) {
+    currentPage.push({ text: '', fontSize: 11, lineHeight: 14 });
+  }
+
+  pages.push(currentPage);
+
+  return pages;
+}
+
+function serializePdf(contentStreams: string[]) {
+  const objects: Array<string | null> = [
+    null,
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  const pageObjectNumbers: number[] = [];
+
+  for (const content of contentStreams) {
+    const pageObjectNumber = objects.length;
+    const contentObjectNumber = pageObjectNumber + 1;
+    pageObjectNumbers.push(pageObjectNumber);
+    objects.push(
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PDF_PAGE_WIDTH} ${PDF_PAGE_HEIGHT}] /Resources << /Font << /F1 3 0 R >> >> /Contents ${contentObjectNumber} 0 R >>`,
+    );
+    objects.push(
+      `<< /Length ${new TextEncoder().encode(content).length} >>\nstream\n${content}\nendstream`,
+    );
+  }
+
+  objects[2] = `<< /Type /Pages /Kids [${pageObjectNumbers
+    .map((objectNumber) => `${objectNumber} 0 R`)
+    .join(' ')}] /Count ${pageObjectNumbers.length} >>`;
+
+  let pdf = '%PDF-1.4\n%\xE2\xE3\xCF\xD3\n';
+  const offsets = [0];
+
+  for (let index = 1; index < objects.length; index += 1) {
+    offsets[index] = pdf.length;
+    pdf += `${index} 0 obj\n${objects[index]}\nendobj\n`;
+  }
+
+  const xrefOffset = pdf.length;
+  pdf += `xref\n0 ${objects.length}\n`;
+  pdf += '0000000000 65535 f \n';
+
+  for (let index = 1; index < objects.length; index += 1) {
+    pdf += `${String(offsets[index]).padStart(10, '0')} 00000 n \n`;
+  }
+
+  pdf += `trailer\n<< /Size ${objects.length} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+
+  return new TextEncoder().encode(pdf);
+}
+
+export const buildWorkflowDocumentPdf = (input: WorkflowDocumentInput) => {
+  const text = htmlToPlainText(buildWorkflowDocumentHtml(input));
+  const lines = buildPdfLines(text);
+  const pages = paginatePdfLines(lines);
+
+  return serializePdf(buildPdfContent(pages));
 };

--- a/apps/worker/src/modules/workflow/workflow.notifications.ts
+++ b/apps/worker/src/modules/workflow/workflow.notifications.ts
@@ -49,6 +49,7 @@ export const buildReviewNotifications = (input: {
       input.baseUrl,
       buildReviewUrl(reviewRequest.reviewToken),
     );
+    const documentUrl = buildAbsoluteUrl(input.baseUrl, document?.fileUrl ?? null);
     const intro = `${reviewRequest.reviewerName ?? reviewRequest.reviewerEmail}, please review and sign ${
       document?.fileName ?? 'the requested document'
     }.`;
@@ -57,9 +58,10 @@ export const buildReviewNotifications = (input: {
       `Document: ${document?.documentType ?? 'Generated document'}`,
       `Role: ${titleCaseRole(reviewRequest.signerRole)}`,
     ];
-    const links = reviewUrl
-      ? [{ label: 'Open review request', url: reviewUrl }]
-      : [];
+    const links = [
+      reviewUrl ? { label: 'Open review request', url: reviewUrl } : null,
+      documentUrl ? { label: 'Open current document', url: documentUrl } : null,
+    ].filter((link): link is { label: string; url: string } => Boolean(link));
 
     return {
       type: 'review_request',

--- a/apps/worker/src/modules/workflow/workflow.service.ts
+++ b/apps/worker/src/modules/workflow/workflow.service.ts
@@ -1,4 +1,7 @@
-export { buildWorkflowDocumentHtml } from './workflow.documents';
+export {
+  buildWorkflowDocumentHtml,
+  buildWorkflowDocumentPdf,
+} from './workflow.documents';
 export {
   buildCompletionNotifications,
   buildDocumentsGeneratedNotifications,

--- a/apps/worker/src/modules/workflow/workflow.types.ts
+++ b/apps/worker/src/modules/workflow/workflow.types.ts
@@ -51,6 +51,7 @@ export type ReviewRequestLike = {
 export type DocumentLike = {
   id: string;
   fileName: string;
+  fileUrl?: string | null;
   documentType: string;
   actionName: string;
 };


### PR DESCRIPTION
## Summary

Updated the notification logic to support the new signing workflow from employee to HR to HR team.

## Problem

The existing notification logic did not cover the full document signing and handoff process, which caused gaps in notifying the right users at each stage of the workflow.

## Changes

* Updated notification logic for the new signing flow
* Added notification handling for employee signing
* Added notification handling for HR signing
* Added notification handoff to the HR team
* Verified notifications are triggered in the correct order: employee -> sign -> HR -> sign -> HR team

## How to Test

Steps to verify the change:

1. Pull the branch and install dependencies
2. Run the application
3. Start the workflow as an employee and complete the signing step
4. Verify HR receives the next notification
5. Complete the HR signing step
6. Verify the HR team receives the final notification

## Issue

Closes #75 